### PR TITLE
Prince/Reusable workflow

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -13,6 +13,6 @@ permissions:
 jobs:
   call-ai-analysis:
     uses: prince-deriv/shared-actions/.github/workflows/ai-code-analysis.yml@master
-    with:
-      personal_access_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      github_token: ${{ secrets.GITHUB_TOKEN }} 
+    secrets:
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/ai-dashboard.yml
+++ b/.github/workflows/ai-dashboard.yml
@@ -20,6 +20,6 @@ permissions:
 jobs:
   call-dashboard-update:
     uses: prince-deriv/shared-actions/.github/workflows/ai-dashboard.yml@master
-    with:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
-      shiftai_token: ${{ secrets.SHIFTAI_TOKEN }} 
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SHIFTAI_TOKEN: ${{ secrets.SHIFTAI_TOKEN }} 


### PR DESCRIPTION
- Changed from 'with:' to 'secrets:' section for token passing
- Fixed ai-code-analysis.yml: PERSONAL_ACCESS_TOKEN and GITHUB_TOKEN now passed as secrets
- Fixed ai-dashboard.yml: GITHUB_TOKEN and SHIFTAI_TOKEN now passed as secrets
- Resolves 'Unrecognized named-value: secrets' validation errors
- Aligns with updated reusable workflow definitions in prince-deriv/shared-actions

## Changes:

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
