### PR TITLE
🚫 Remove GITHUB_TOKEN from secrets to fix reserved name collision

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -15,4 +15,4 @@ jobs:
     uses: prince-deriv/shared-actions/.github/workflows/ai-code-analysis.yml@master
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+    # Note: GITHUB_TOKEN is automatically available via github.token, no need to pass explicitly 

--- a/.github/workflows/ai-dashboard.yml
+++ b/.github/workflows/ai-dashboard.yml
@@ -21,5 +21,5 @@ jobs:
   call-dashboard-update:
     uses: prince-deriv/shared-actions/.github/workflows/ai-dashboard.yml@master
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SHIFTAI_TOKEN: ${{ secrets.SHIFTAI_TOKEN }} 
+      SHIFTAI_TOKEN: ${{ secrets.SHIFTAI_TOKEN }}
+    # Note: GITHUB_TOKEN is automatically available via github.token, no need to pass explicitly 


### PR DESCRIPTION
- Removed GITHUB_TOKEN from ai-code-analysis.yml secrets section
- Removed GITHUB_TOKEN from ai-dashboard.yml secrets section
- GITHUB_TOKEN is system reserved and automatically available via github.token
- Fixes error: 'secret name GITHUB_TOKEN within workflow_call can not be used since it would collide with system reserved name'
- Only custom secrets (PERSONAL_ACCESS_TOKEN, SHIFTAI_TOKEN) are now explicitly passed

## Changes:

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
